### PR TITLE
Resolve DOIs securely

### DIFF
--- a/lib/serrano/cnrequest.rb
+++ b/lib/serrano/cnrequest.rb
@@ -30,7 +30,7 @@ module Serrano
         raise "format not one of accepted types"
       end
 
-      $conn = Faraday.new "http://dx.doi.org/" do |c|
+      $conn = Faraday.new "https://doi.org/" do |c|
         c.use FaradayMiddleware::FollowRedirects
         c.adapter :net_http
       end


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the URL prefix used in HTTP requests. If I understood the code correctly.

Cheers!