### PR TITLE
Add information on filters, as well as checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Search works by query string
 Serrano.works(query: "ecology")
 ```
 
+Search works using metadata filters. See [CrossRef filter docs(https://github.com/CrossRef/rest-api-doc#filter-names).
+
+```ruby
+Serrano.works(query: "ecology", filter: { has_abstract: true })
+```
+
 Search journals by publisher name
 
 ```ruby

--- a/lib/serrano.rb
+++ b/lib/serrano.rb
@@ -234,6 +234,8 @@ module Serrano
                  select: nil, options: nil, verbose: false, cursor: nil,
                  cursor_max: 5000, **args)
 
+    assert_valid_filters(filter) if filter
+
     RequestCursor.new('works', ids, query, filter, offset,
                       limit, sample, sort, order, facet, select, nil, nil, options,
                       verbose, cursor, cursor_max, args).perform
@@ -669,4 +671,27 @@ module Serrano
   def self.csl_styles
     fetch_styles
   end
+
+  private
+
+  def self.assert_valid_filters(filters)
+    unless filters.is_a? Hash
+      raise ArgumentError, <<~ERR
+        Filters must be provided as a hash, like:
+
+        Serrano.works(query: "something", filters: { has_abstract: true })
+      ERR
+    end
+
+    filters.each do |name, _|
+      unless Filters.names.map(&:to_s).include? name.to_s
+        raise ArgumentError, <<~ERR
+          The filter "#{name}" is not a valid filter.
+
+          Please run `Serrano.filters.details` to see all valid filters.
+        ERR
+      end
+    end
+  end
+
 end

--- a/lib/serrano.rb
+++ b/lib/serrano.rb
@@ -672,26 +672,22 @@ module Serrano
     fetch_styles
   end
 
-  private
-
   def self.assert_valid_filters(filters)
     unless filters.is_a? Hash
       raise ArgumentError, <<~ERR
         Filters must be provided as a hash, like:
 
-        Serrano.works(query: "something", filters: { has_abstract: true })
+            Serrano.works(query: "something", filters: { has_abstract: true })
       ERR
     end
 
     filters.each do |name, _|
-      unless Filters.names.map(&:to_s).include? name.to_s
-        raise ArgumentError, <<~ERR
-          The filter "#{name}" is not a valid filter.
+      filter_strings = Filters.names.map(&:to_s)
+      next if filter_strings.include?(name.to_s)
 
-          Please run `Serrano.filters.details` to see all valid filters.
-        ERR
-      end
+      raise ArgumentError, <<~ERR
+        The filter "#{name}" is not a valid filter. Please run `Serrano.filters.details` to see all valid filters.
+      ERR
     end
   end
-
 end

--- a/lib/serrano/filters.rb
+++ b/lib/serrano/filters.rb
@@ -14,7 +14,6 @@
 #    Serrano::Filters.filters['has_funder']
 #    Serrano::Filters.filters['has_funder']['description']
 module Serrano
-
   def self.filters
     Filters
   end
@@ -100,6 +99,6 @@ module Serrano
       'public_references' => { 'possible_values' => nil, 'description' => 'metadata where publishers allow references to be distributed publically' },
       'publisher_name' => { 'possible_values' => nil, 'description' => 'metadata for records with an exact matching publisher name' },
       'affiliation' => { 'possible_values' => nil, 'description' => 'metadata for records with at least one contributor with the given affiliation' }
-    }
+    }.freeze
   end
 end

--- a/lib/serrano/filters.rb
+++ b/lib/serrano/filters.rb
@@ -14,83 +14,92 @@
 #    Serrano::Filters.filters['has_funder']
 #    Serrano::Filters.filters['has_funder']['description']
 module Serrano
+
+  def self.filters
+    Filters
+  end
+
   module Filters
     def self.names
-      filter_details.keys
+      FILTER_DETAILS.keys
     end
 
     def self.filters
-      filter_details
+      FILTER_DETAILS
     end
+
+    def self.details
+      FILTER_DETAILS
+    end
+
+    FILTER_DETAILS = {
+      'has_funder' => { 'possible_values' => nil, 'description' => 'metadata which includes one or more funder entry' },
+      'funder' => { 'possible_values' => '{funder_id}', 'description' => 'metadata which include the {funder_id} in FundRef data' },
+      'location' => { 'possible_values' => '{country_name}', 'description' => 'funder records where location = {country name}. Only works on /funders route' },
+      'prefix' => { 'possible_values' => '{owner_prefix}', 'description' => "metadata belonging to a DOI owner prefix {owner_prefix} (e.g. '10.1016' )" },
+      'member' => { 'possible_values' => '{member_id}', 'description' => 'metadata belonging to a CrossRef member' },
+      'from_index_date' => { 'possible_values' => '{date}', 'description' => 'metadata indexed since (inclusive) {date}' },
+      'until_index_date' => { 'possible_values' => '{date}', 'description' => 'metadata indexed before (inclusive) {date}' },
+      'from_deposit_date' => { 'possible_values' => '{date}', 'description' => 'metadata last (re)deposited since (inclusive) {date}' },
+      'until_deposit_date' => { 'possible_values' => '{date}', 'description' => 'metadata last (re)deposited before (inclusive) {date}' },
+      'from_update_date' => { 'possible_values' => '{date}', 'description' => "Metadata updated since (inclusive) {date} Currently the same as 'from_deposit_date'" },
+      'until_update_date' => { 'possible_values' => '{date}', 'description' => "Metadata updated before (inclusive) {date} Currently the same as 'until_deposit_date'" },
+      'from_created_date' => { 'possible_values' => '{date}', 'description' => 'metadata first deposited since (inclusive) {date}' },
+      'until_created_date' => { 'possible_values' => '{date}', 'description' => 'metadata first deposited before (inclusive) {date}' },
+      'from_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where published date is since (inclusive) {date}' },
+      'until_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where published date is before (inclusive)  {date}' },
+      'from_online_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where online published date is since (inclusive) {date}' },
+      'until_online_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where online published date is before (inclusive) {date}' },
+      'from_print_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where print published date is since (inclusive) {date}' },
+      'until_print_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where print published date is before (inclusive) {date}' },
+      'from_posted_date' => { 'possible_values' => '{date}', 'description' => 'metadata where posted date is since (inclusive) {date}' },
+      'until_posted_date' => { 'possible_values' => '{date}', 'description' => 'metadata where posted date is before (inclusive) {date}' },
+      'from_accepted_date' => { 'possible_values' => '{date}', 'description' => 'metadata where accepted date is since (inclusive) {date}' },
+      'until_accepted_date' => { 'possible_values' => '{date}', 'description' => 'metadata where accepted date is before (inclusive) {date}' },
+      'has_license' => { 'possible_values' => nil, 'description' => "metadata that includes any '<license_ref>' elements" },
+      'license_url' => { 'possible_values' => '{url}', 'description' => "metadata where '<license_ref>' value equals {url}" },
+      'license_version' => { 'possible_values' => '{string}', 'description' => "metadata where the '<license_ref>''s 'applies_to' attribute  is '{string}'" },
+      'license_delay' => { 'possible_values' => '{integer}', 'description' => "metadata where difference between publication date and the '<license_ref>''s 'start_date' attribute is <= '{integer}' (in days" },
+      'has_full_text' => { 'possible_values' => nil, 'description' => "metadata that includes any full text '<resource>' elements_" },
+      'full_text_version' => { 'possible_values' => '{string}', 'description' => "metadata where '<resource>' element's 'content_version' attribute is '{string}'" },
+      'full_text_type' => { 'possible_values' => '{mime_type}', 'description' => "metadata where '<resource>' element's 'content_type' attribute is '{mime_type}' (e.g. 'application/pdf')" },
+      'full_text_application' => { 'possible_values' => '{string}', 'description' => 'metadata where <resource> link has one of the following intended applications: text-mining, similarity-checking or unspecified' },
+      'has_references' => { 'possible_values' => nil, 'description' => 'metadata for works that have a list of references' },
+      'has_archive' => { 'possible_values' => nil, 'description' => 'metadata which include name of archive partner' },
+      'archive' => { 'possible_values' => '{string}', 'description' => "metadata which where value of archive partner is '{string}'" },
+      'has_orcid' => { 'possible_values' => nil, 'description' => 'metadata which includes one or more ORCIDs' },
+      'has_authenticated_orcid' => { 'possible_values' => nil, 'description' => 'metadata which includes one or more ORCIDs where the depositing publisher claims to have witness the ORCID owner authenticate with ORCID' },
+      'orcid' => { 'possible_values' => '{orcid}', 'description' => "metadata where '<orcid>' element's value = '{orcid}'" },
+      'issn' => { 'possible_values' => '{issn}', 'description' => "metadata where record has an ISSN = '{issn}' Format is 'xxxx_xxxx'." },
+      'directory' => { 'possible_values' => '{directory}', 'description' => "metadata records whose article or serial are mentioned in the given '{directory}'. Currently the only supported value is 'doaj'" },
+      'doi' => { 'possible_values' => '{doi}', 'description' => "metadata describing the DOI '{doi}'" },
+      'updates' => { 'possible_values' => '{doi}', 'description' => "metadata for records that represent editorial updates to the DOI '{doi}'" },
+      'is_update' => { 'possible_values' => nil, 'description' => 'metadata for records that represent editorial updates' },
+      'has_update_policy' => { 'possible_values' => nil, 'description' => 'metadata for records that include a link to an editorial update policy' },
+      'container_title' => { 'possible_values' => nil, 'description' => 'metadata for records with a publication title exactly with an exact match' },
+      'category_name' => { 'possible_values' => nil, 'description' => 'metadata for records with an exact matching category label' },
+      'type' => { 'possible_values' => '{type}', 'description' => "metadata records whose type = '{type}' Type must be an ID value from the list of types returned by the '/types' resource" },
+      'type_name' => { 'possible_values' => nil, 'description' => 'metadata for records with an exacty matching type label' },
+      'award_number' => { 'possible_values' => '{award_number}', 'description' => "metadata for records with a matching award nunber_ Optionally combine with 'award_funder'" },
+      'award_funder' => { 'possible_values' => '{funder doi or id}', 'description' => "metadata for records with an award with matching funder. Optionally combine with 'award_number'" },
+      'has_assertion' => { 'possible_values' => nil, 'description' => 'metadata for records with any assertions' },
+      'assertion_group' => { 'possible_values' => nil, 'description' => 'metadata for records with an assertion in a particular group' },
+      'assertion' => { 'possible_values' => nil, 'description' => 'metadata for records with a particular named assertion' },
+      'has_affiliation' => { 'possible_values' => nil, 'description' => 'metadata for records that have any affiliation information' },
+      'alternative_id' => { 'possible_values' => nil, 'description' => 'metadata for records with the given alternative ID, which may be a publisher_specific ID, or any other identifier a publisher may have provided' },
+      'article_number' => { 'possible_values' => nil, 'description' => 'metadata for records with a given article number' },
+      'has_abstract' => { 'possible_values' => nil, 'description' => 'metadata for records which include an abstract' },
+      'has_clinical_trial_number' => { 'possible_values' => nil, 'description' => 'metadata for records which include a clinical trial number' },
+      'content_domain' => { 'possible_values' => nil, 'description' => 'metadata where the publisher records a particular domain name as the location Crossmark content will appear' },
+      'has_content_domain' => { 'possible_values' => nil, 'description' => 'metadata where the publisher records a domain name location for Crossmark content' },
+      'has_crossmark_restriction' => { 'possible_values' => nil, 'description' => 'metadata where the publisher restricts Crossmark usage to content domains' },
+      'has_relation' => { 'possible_values' => nil, 'description' => 'metadata for records that either assert or are the object of a relation' },
+      'relation_type' => { 'possible_values' => nil, 'description' => 'One of the relation types from the Crossref relations schema (e.g. is-referenced-by, is-parent-of, is-preprint-of)' },
+      'relation_object' => { 'possible_values' => nil, 'description' => 'Relations where the object identifier matches the identifier provided' },
+      'relation_object_type' => { 'possible_values' => nil, 'description' => 'One of the identifier types from the Crossref relations schema (e.g. doi, issn)' },
+      'public_references' => { 'possible_values' => nil, 'description' => 'metadata where publishers allow references to be distributed publically' },
+      'publisher_name' => { 'possible_values' => nil, 'description' => 'metadata for records with an exact matching publisher name' },
+      'affiliation' => { 'possible_values' => nil, 'description' => 'metadata for records with at least one contributor with the given affiliation' }
+    }
   end
 end
-
-filter_details = {
-  'has_funder' => { 'possible_values' => nil, 'description' => 'metadata which includes one or more funder entry' },
-  'funder' => { 'possible_values' => '{funder_id}', 'description' => 'metadata which include the {funder_id} in FundRef data' },
-  'location' => { 'possible_values' => '{country_name}', 'description' => 'funder records where location = {country name}. Only works on /funders route' },
-  'prefix' => { 'possible_values' => '{owner_prefix}', 'description' => "metadata belonging to a DOI owner prefix {owner_prefix} (e.g. '10.1016' )" },
-  'member' => { 'possible_values' => '{member_id}', 'description' => 'metadata belonging to a CrossRef member' },
-  'from_index_date' => { 'possible_values' => '{date}', 'description' => 'metadata indexed since (inclusive) {date}' },
-  'until_index_date' => { 'possible_values' => '{date}', 'description' => 'metadata indexed before (inclusive) {date}' },
-  'from_deposit_date' => { 'possible_values' => '{date}', 'description' => 'metadata last (re)deposited since (inclusive) {date}' },
-  'until_deposit_date' => { 'possible_values' => '{date}', 'description' => 'metadata last (re)deposited before (inclusive) {date}' },
-  'from_update_date' => { 'possible_values' => '{date}', 'description' => "Metadata updated since (inclusive) {date} Currently the same as 'from_deposit_date'" },
-  'until_update_date' => { 'possible_values' => '{date}', 'description' => "Metadata updated before (inclusive) {date} Currently the same as 'until_deposit_date'" },
-  'from_created_date' => { 'possible_values' => '{date}', 'description' => 'metadata first deposited since (inclusive) {date}' },
-  'until_created_date' => { 'possible_values' => '{date}', 'description' => 'metadata first deposited before (inclusive) {date}' },
-  'from_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where published date is since (inclusive) {date}' },
-  'until_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where published date is before (inclusive)  {date}' },
-  'from_online_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where online published date is since (inclusive) {date}' },
-  'until_online_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where online published date is before (inclusive) {date}' },
-  'from_print_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where print published date is since (inclusive) {date}' },
-  'until_print_pub_date' => { 'possible_values' => '{date}', 'description' => 'metadata where print published date is before (inclusive) {date}' },
-  'from_posted_date' => { 'possible_values' => '{date}', 'description' => 'metadata where posted date is since (inclusive) {date}' },
-  'until_posted_date' => { 'possible_values' => '{date}', 'description' => 'metadata where posted date is before (inclusive) {date}' },
-  'from_accepted_date' => { 'possible_values' => '{date}', 'description' => 'metadata where accepted date is since (inclusive) {date}' },
-  'until_accepted_date' => { 'possible_values' => '{date}', 'description' => 'metadata where accepted date is before (inclusive) {date}' },
-  'has_license' => { 'possible_values' => nil, 'description' => "metadata that includes any '<license_ref>' elements" },
-  'license_url' => { 'possible_values' => '{url}', 'description' => "metadata where '<license_ref>' value equals {url}" },
-  'license_version' => { 'possible_values' => '{string}', 'description' => "metadata where the '<license_ref>''s 'applies_to' attribute  is '{string}'" },
-  'license_delay' => { 'possible_values' => '{integer}', 'description' => "metadata where difference between publication date and the '<license_ref>''s 'start_date' attribute is <= '{integer}' (in days" },
-  'has_full_text' => { 'possible_values' => nil, 'description' => "metadata that includes any full text '<resource>' elements_" },
-  'full_text_version' => { 'possible_values' => '{string}', 'description' => "metadata where '<resource>' element's 'content_version' attribute is '{string}'" },
-  'full_text_type' => { 'possible_values' => '{mime_type}', 'description' => "metadata where '<resource>' element's 'content_type' attribute is '{mime_type}' (e.g. 'application/pdf')" },
-  'full_text_application' => { 'possible_values' => '{string}', 'description' => 'metadata where <resource> link has one of the following intended applications: text-mining, similarity-checking or unspecified' },
-  'has_references' => { 'possible_values' => nil, 'description' => 'metadata for works that have a list of references' },
-  'has_archive' => { 'possible_values' => nil, 'description' => 'metadata which include name of archive partner' },
-  'archive' => { 'possible_values' => '{string}', 'description' => "metadata which where value of archive partner is '{string}'" },
-  'has_orcid' => { 'possible_values' => nil, 'description' => 'metadata which includes one or more ORCIDs' },
-  'has_authenticated_orcid' => { 'possible_values' => nil, 'description' => 'metadata which includes one or more ORCIDs where the depositing publisher claims to have witness the ORCID owner authenticate with ORCID' },
-  'orcid' => { 'possible_values' => '{orcid}', 'description' => "metadata where '<orcid>' element's value = '{orcid}'" },
-  'issn' => { 'possible_values' => '{issn}', 'description' => "metadata where record has an ISSN = '{issn}' Format is 'xxxx_xxxx'." },
-  'directory' => { 'possible_values' => '{directory}', 'description' => "metadata records whose article or serial are mentioned in the given '{directory}'. Currently the only supported value is 'doaj'" },
-  'doi' => { 'possible_values' => '{doi}', 'description' => "metadata describing the DOI '{doi}'" },
-  'updates' => { 'possible_values' => '{doi}', 'description' => "metadata for records that represent editorial updates to the DOI '{doi}'" },
-  'is_update' => { 'possible_values' => nil, 'description' => 'metadata for records that represent editorial updates' },
-  'has_update_policy' => { 'possible_values' => nil, 'description' => 'metadata for records that include a link to an editorial update policy' },
-  'container_title' => { 'possible_values' => nil, 'description' => 'metadata for records with a publication title exactly with an exact match' },
-  'category_name' => { 'possible_values' => nil, 'description' => 'metadata for records with an exact matching category label' },
-  'type' => { 'possible_values' => '{type}', 'description' => "metadata records whose type = '{type}' Type must be an ID value from the list of types returned by the '/types' resource" },
-  'type_name' => { 'possible_values' => nil, 'description' => 'metadata for records with an exacty matching type label' },
-  'award_number' => { 'possible_values' => '{award_number}', 'description' => "metadata for records with a matching award nunber_ Optionally combine with 'award_funder'" },
-  'award_funder' => { 'possible_values' => '{funder doi or id}', 'description' => "metadata for records with an award with matching funder. Optionally combine with 'award_number'" },
-  'has_assertion' => { 'possible_values' => nil, 'description' => 'metadata for records with any assertions' },
-  'assertion_group' => { 'possible_values' => nil, 'description' => 'metadata for records with an assertion in a particular group' },
-  'assertion' => { 'possible_values' => nil, 'description' => 'metadata for records with a particular named assertion' },
-  'has_affiliation' => { 'possible_values' => nil, 'description' => 'metadata for records that have any affiliation information' },
-  'alternative_id' => { 'possible_values' => nil, 'description' => 'metadata for records with the given alternative ID, which may be a publisher_specific ID, or any other identifier a publisher may have provided' },
-  'article_number' => { 'possible_values' => nil, 'description' => 'metadata for records with a given article number' },
-  'has_abstract' => { 'possible_values' => nil, 'description' => 'metadata for records which include an abstract' },
-  'has_clinical_trial_number' => { 'possible_values' => nil, 'description' => 'metadata for records which include a clinical trial number' },
-  'content_domain' => { 'possible_values' => nil, 'description' => 'metadata where the publisher records a particular domain name as the location Crossmark content will appear' },
-  'has_content_domain' => { 'possible_values' => nil, 'description' => 'metadata where the publisher records a domain name location for Crossmark content' },
-  'has_crossmark_restriction' => { 'possible_values' => nil, 'description' => 'metadata where the publisher restricts Crossmark usage to content domains' },
-  'has_relation' => { 'possible_values' => nil, 'description' => 'metadata for records that either assert or are the object of a relation' },
-  'relation_type' => { 'possible_values' => nil, 'description' => 'One of the relation types from the Crossref relations schema (e.g. is-referenced-by, is-parent-of, is-preprint-of)' },
-  'relation_object' => { 'possible_values' => nil, 'description' => 'Relations where the object identifier matches the identifier provided' },
-  'relation_object_type' => { 'possible_values' => nil, 'description' => 'One of the identifier types from the Crossref relations schema (e.g. doi, issn)' },
-  'public_references' => { 'possible_values' => nil, 'description' => 'metadata where publishers allow references to be distributed publically' },
-  'publisher_name' => { 'possible_values' => nil, 'description' => 'metadata for records with an exact matching publisher name' },
-  'affiliation' => { 'possible_values' => nil, 'description' => 'metadata for records with at least one contributor with the given affiliation' }
-}

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -12,13 +12,12 @@ require 'test/unit'
 require_relative 'test-helper'
 
 class TestFilters < Test::Unit::TestCase
-
   def test_filter_name_metadata
-    assert_equal "affiliation", Serrano::Filters.names.sort.first
+    assert_equal 'affiliation', Serrano::Filters.names.min
   end
 
   def test_filter_detail_metadata
-    expected_keys = ['possible_values', 'description'].sort
+    expected_keys = %w[possible_values description].sort
     actual_keys = Serrano::Filters.filters['affiliation'].keys.sort
     assert_equal expected_keys, actual_keys
   end

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start
+if ENV['CI'] == 'true'
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+end
+
+require 'serrano'
+require 'test/unit'
+require_relative 'test-helper'
+
+class TestFilters < Test::Unit::TestCase
+
+  def test_filter_name_metadata
+    assert_equal "affiliation", Serrano::Filters.names.sort.first
+  end
+
+  def test_filter_detail_metadata
+    expected_keys = ['possible_values', 'description'].sort
+    actual_keys = Serrano::Filters.filters['affiliation'].keys.sort
+    assert_equal expected_keys, actual_keys
+  end
+
+  def test_method_alias
+    assert_equal Serrano::Filters.names,   Serrano.filters.names
+    assert_equal Serrano::Filters.filters, Serrano.filters.details
+  end
+end

--- a/test/test_works.rb
+++ b/test/test_works.rb
@@ -57,17 +57,17 @@ class TestWorks < Test::Unit::TestCase
   end
 
   def test_bad_filter_structure_raises_exception
-    assert_raises(ArgumentError) {
+    assert_raises(ArgumentError) do
       # Uses a string instead of a hash
-      Serrano.works(filter: "has-abstract")
-    }
+      Serrano.works(filter: 'has-abstract')
+    end
   end
 
   def test_bad_filter_content_raises_exception
-    assert_raises(ArgumentError) {
+    assert_raises(ArgumentError) do
       # Uses an incorrect filter name
-      Serrano.works(filter: { "has_nonsense" => true })
-    }
+      Serrano.works(filter: { 'has_nonsense' => true })
+    end
   end
 
   def test_works_sort

--- a/test/test_works.rb
+++ b/test/test_works.rb
@@ -56,6 +56,20 @@ class TestWorks < Test::Unit::TestCase
     # assert_equal(200, res.status)
   end
 
+  def test_bad_filter_structure_raises_exception
+    assert_raises(ArgumentError) {
+      # Uses a string instead of a hash
+      Serrano.works(filter: "has-abstract")
+    }
+  end
+
+  def test_bad_filter_content_raises_exception
+    assert_raises(ArgumentError) {
+      # Uses an incorrect filter name
+      Serrano.works(filter: { "has_nonsense" => true })
+    }
+  end
+
   def test_works_sort
     VCR.use_cassette('test_works_sort') do
       res1 = Serrano.works(query: 'ecology', sort: 'relevance')


### PR DESCRIPTION
Previously, there was no information in the README about filters, and running Serrano::Filters in a repl didn't provide any information (although we could read the code in the file).

This commit adds information about filters to the README, provides access to filter names and information in the library, and checks before running a request to make sure that filters are formatted as a hash and that the filters provided are valid filters.