### PR TITLE
add REXML dependency

### DIFF
--- a/serrano.gemspec
+++ b/serrano.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "faraday", "~> 1.1"
   s.add_runtime_dependency "faraday_middleware", "~> 1.0"
   s.add_runtime_dependency "multi_json", '~> 1.15'
+  s.add_runtime_dependency "rexml", '~> 3.2', '>= 3.2.4'
   s.add_runtime_dependency 'thor', '~> 1.0', '>= 1.0.1'
 
   s.metadata = {


### PR DESCRIPTION
REXML [is used](https://github.com/sckott/serrano/blob/master/lib/serrano.rb#L12-L13) in Serrano but not declared as a dependency. Bundler will install it only if the development dependencies are installed, via `webmock`-> `crack` -> `rexml`, but that is not usually the case in production deployments, where the `development` or `test` dependency groups (the ones usually including webmock) are ignored.

This PR adds REXML as a runtime dependency