### PR TITLE
Not found returned as valid data

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,3 +44,8 @@ desc "Release to Rubygems"
 task release: :build do
   system "gem push serrano-#{Serrano::VERSION}.gem"
 end
+
+desc 'open an irb session preloaded with this gem'
+task :console do
+  sh 'irb -r pp -r ./lib/serrano.rb'
+end

--- a/lib/serrano/cnrequest.rb
+++ b/lib/serrano/cnrequest.rb
@@ -87,7 +87,7 @@ def make_request(conn, ids, format, style, locale)
     }
   end
 
-  res.body
+  res.body if res.success?
 end
 
 # parser <- cn_types[[self.format]]


### PR DESCRIPTION
When using `Serrano.content_negotiation(ids: ["doi:10.5281/zenodo.4406210"], format: "citeproc-json")` it returns `Resource not found` as response which is not valid JSON.

This small pull request fixes the problem by returning nil if the response was not successful. I also added `console` task to facilitate testing the gem inside `irb`.